### PR TITLE
[WIP] Update Jetpack to 4.6.1

### DIFF
--- a/exporters/trt_exporter.py
+++ b/exporters/trt_exporter.py
@@ -63,16 +63,15 @@ def export_trt(pb_file, output_dir, num_classes=90, neuralet_adaptive_model=1):
         text=True,
         debug_mode=False)
     input_dims = (3, 300, 300)
-    with trt.Builder(TRT_LOGGER) as builder, builder.create_network() as network, trt.UffParser() as parser:
-        config = builder.create_builder_config()
-        config.max_workspace_size = 1 << 28
+    with trt.Builder(TRT_LOGGER) as builder, builder.create_network() as network, builder.create_builder_config() as builder_config, trt.UffParser() as parser:
+        builder_config.max_workspace_size = 1 << 28
         builder.max_batch_size = 1
-        #builder.fp16_mode = True TODO: Deprecated in TRT8 is it done automatically?
+        builder_config.set_flag(trt.BuilderFlag.FP16)
 
         parser.register_input('Input', input_dims)
         parser.register_output('MarkOutput_0')
         parser.parse(uff_path, network)
-        engine = builder.build_engine(network, config)
+        engine = builder.build_engine(network, builder_config)
         
         buf = engine.serialize()
         engine_path = os.path.join(output_dir, model_file_name + ".bin")

--- a/exporters/trt_exporter.py
+++ b/exporters/trt_exporter.py
@@ -64,14 +64,15 @@ def export_trt(pb_file, output_dir, num_classes=90, neuralet_adaptive_model=1):
         debug_mode=False)
     input_dims = (3, 300, 300)
     with trt.Builder(TRT_LOGGER) as builder, builder.create_network() as network, trt.UffParser() as parser:
-        builder.max_workspace_size = 1 << 28
+        config = builder.create_builder_config()
+        config.max_workspace_size = 1 << 28
         builder.max_batch_size = 1
-        builder.fp16_mode = True
+        #builder.fp16_mode = True TODO: Deprecated in TRT8 is it done automatically?
 
         parser.register_input('Input', input_dims)
         parser.register_output('MarkOutput_0')
         parser.parse(uff_path, network)
-        engine = builder.build_cuda_engine(network)
+        engine = builder.build_engine(network, config)
         
         buf = engine.serialize()
         engine_path = os.path.join(output_dir, model_file_name + ".bin")

--- a/jetson-nano.Dockerfile
+++ b/jetson-nano.Dockerfile
@@ -3,9 +3,9 @@
 # 1) build: docker build -f Dockerfile -t "neuralet/jetson-nano:tf-ssd-to-trt" .
 # 2) run: docker run -it --runtime nvidia --privileged --network host -v /PATH_TO_DOCKERFILE_DIRECTORY/:/repo neuralet/jetson-nano:tf-ssd-to-trt
 
-#FROM nvcr.io/nvidia/l4t-base:r32.4.4
+#FROM nvcr.io/nvidia/l4t-base:r32.6.1
 
-FROM nvcr.io/nvidia/l4t-tensorflow:r32.4.4-tf1.15-py3
+FROM nvcr.io/nvidia/l4t-tensorflow:r32.6.1-tf1.15-py3
 ENV TZ=US/Pacific
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -31,7 +31,7 @@ RUN apt-get install -y graphsurgeon-tf uff-converter-tf
 RUN pip3 install protobuf
 RUN apt-get install -y pkg-config libhdf5-100 libhdf5-dev
 RUN apt-get install -y python3-h5py python3-opencv
-RUN pip3 install wget pillow
+RUN pip3 install wget pillow nvidia-pyindex
 
 COPY ./exporters/libflattenconcat.so.6 /opt/libflattenconcat.so 
 RUN apt update && apt install -y libtcmalloc-minimal4

--- a/jetson-nano.Dockerfile
+++ b/jetson-nano.Dockerfile
@@ -3,8 +3,6 @@
 # 1) build: docker build -f Dockerfile -t "neuralet/jetson-nano:tf-ssd-to-trt" .
 # 2) run: docker run -it --runtime nvidia --privileged --network host -v /PATH_TO_DOCKERFILE_DIRECTORY/:/repo neuralet/jetson-nano:tf-ssd-to-trt
 
-#FROM nvcr.io/nvidia/l4t-base:r32.6.1
-
 FROM nvcr.io/nvidia/l4t-tensorflow:r32.6.1-tf1.15-py3
 ENV TZ=US/Pacific
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -31,7 +29,7 @@ RUN apt-get install -y graphsurgeon-tf uff-converter-tf
 RUN pip3 install protobuf
 RUN apt-get install -y pkg-config libhdf5-100 libhdf5-dev
 RUN apt-get install -y python3-h5py python3-opencv
-RUN pip3 install wget pillow nvidia-pyindex
+RUN pip3 install wget pillow
 
 COPY ./exporters/libflattenconcat.so.6 /opt/libflattenconcat.so 
 RUN apt update && apt install -y libtcmalloc-minimal4


### PR DESCRIPTION
Update the jetpack version of the dockerfile to 4.6.1 and thus the TensorRT version to 8.

This is a work in progress, right now a model can be generated (using `trt_exporter.py`) but fails when using it on the Pose Detection environment (See https://github.com/neuralet/adaptive-pose-estimation/pull/8)

The raised error has something to do with the batch size (even though it's correctly set), I tried to review the TensorRT documentation and try out some stuff but to no avail.
```
python3 inference/inference.py --device jetson --input_video softbio_vid.mp4 --out_dir inference/ --detector_model_path adaptive_object_detection/detectors/data/frozen_inference_graph.bin --label_map train_outputs/label_map.pbtxt --batch_size 2 --pose_model_path models/data/fast_pose_fp16_b2.trt 
2021-10-05 10:00:38.348486: I tensorflow/stream_executor/platform/default/dso_loader.cc:49] Successfully opened dynamic library libcudart.so.10.2
WARNING:tensorflow:Deprecation warnings have been disabled. Set TF_ENABLE_DEPRECATION_WARNINGS=1 to re-enable them.
opened video  softbio_vid.mp4
WARNING:adaptive_object_detection.detectors.jetson_detector:
WARNING:adaptive_object_detection.detectors.jetson_detector:adaptive_object_detection/detectors/data/frozen_inference_graph.bin
WARNING:adaptive_object_detection.detectors.jetson_detector:
WARNING:root: 
WARNING:root:adaptive_object_detection/detectors/data/frozen_inference_graph.bin
WARNING:root: 
[TensorRT] WARNING: The logger passed into createInferRuntime differs from one already provided for an existing builder, runtime, or refitter. TensorRT maintains only a single logger pointer at any given time, so the existing value, which can be retrieved with getLogger(), will be used instead. In order to use a new logger, first destroy all existing builder, runner or refitter objects.

WARNING:root:started deserialize
WARNING:root:<tensorrt.tensorrt.ICudaEngine object at 0x7f73e99340>
[TensorRT] ERROR: 3: [executionContext.cpp::execute::473] Error Code 3: Internal Error (Parameter check failed at: runtime/api/executionContext.cpp::execute::473, condition: batchSize > 0 && batchSize <= mEngine.getMaxBatchSize()
)
[TensorRT] ERROR: 3: [executionContext.cpp::execute::473] Error Code 3: Internal Error (Parameter check failed at: runtime/api/executionContext.cpp::execute::473, condition: batchSize > 0 && batchSize <= mEngine.getMaxBatchSize()
)

```